### PR TITLE
feat(provider): import context enrichment for TS/JS/TSX (#9)

### DIFF
--- a/.docs/issues/approved/9.md
+++ b/.docs/issues/approved/9.md
@@ -1,0 +1,47 @@
+## What
+
+Extend the import context enrichment (introduced in #1) to TypeScript, JavaScript, and TSX files.
+
+## Why
+
+Issue #1 implements the `ImportExtractor` protocol and registry with Python as the first language. This issue adds extractors for the JS/TS ecosystem, which has different resolution rules (implicit extensions, `index.ts` fallback, path aliases via tsconfig).
+
+## Acceptance criteria
+
+- [ ] `TypeScriptImportExtractor` handles: `import X from './x'`, `import { a } from './x'`, `import * as X from './x'`, `import type { X } from './x'`, `require('./x')`
+- [ ] Resolves implicit extensions: tries `.ts`, `.tsx`, `.js`, `.jsx`, `index.ts`, `index.tsx` in order
+- [ ] Filters node_modules and bare specifiers (no leading `./` or `../` or absolute path)
+- [ ] Registered for `Language.TS`, `Language.JS`, `Language.TSX` in `_EXTRACTORS`
+- [ ] Unit tests: all import forms, extension resolution, node_modules filtering
+- [ ] README updated to list TS/JS/TSX as supported languages for `--with-context`
+
+---
+
+## Step 1 — `TypeScriptImportExtractor` + unit tests
+
+**File to modify:** `src/sourcemap_indexer/infra/import_extractor.py`
+**Test to modify:** `tests/infra/test_import_extractor.py`
+
+### Checkboxes
+
+- [x] `[RED]` `[AGENT:tdd-test-writer-agent]` Write failing tests for `TypeScriptImportExtractor.extract()` — covers: `import X from './x'`, `import { a } from './x'`, `import * as X from './x'`, `import type { X } from './x'`, `require('./x')`; extension candidates (`.ts/.tsx/.js/.jsx/index.ts/index.tsx`); subdirectory resolution (`../utils` from `src/a/b.ts`); bare specifier filtered (`react`); scoped package filtered (`@scope/pkg`); registered for `Language.TS`, `Language.JS`, `Language.TSX` in `_EXTRACTORS`
+- [x] `[GREEN]` Implement `TypeScriptImportExtractor`: regex captures specifier from all import forms; filter bare specifiers (no `./`, `../`, or `/` prefix); resolve relative to importer dir; return 6 extension candidates per specifier; register for TS/JS/TSX; update `test_extractors_registry_unknown_language_absent` to remove JS/TS/TSX assertions
+- [x] `[AUDIT]` `[AGENT:self-review-agent]` Run step validation
+
+---
+
+## Step 2 — README update + linter audit
+
+**File to modify:** `README.md`
+
+### Checkboxes
+
+- [x] `[INFRA]` Update README `--with-context` section — change "Python only" to "Python, TypeScript, JavaScript, TSX"; note extension candidate resolution
+- [x] `[INFRA]` Audit linter ignore rules — review `# noqa` in `infra/import_extractor.py` and modified test file
+- [x] `[AUDIT]` `[AGENT:self-review-agent]` Run step validation
+
+---
+
+## Post-development phases
+
+`/review` → `/open-pr`

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ All commands are invoked as `sourcemap <command>`.
 | `--layer <layer>` | Filter by architectural layer |
 | `--language <lang>` | Filter by language |
 | `-m "<msg>"` | Inject an extra instruction into the LLM prompt |
-| `--with-context` | Inject depth-1 import context from indexed dependencies into the prompt (Python only; off by default) |
+| `--with-context` | Inject depth-1 import context from indexed dependencies into the prompt (Python, TypeScript, JavaScript, TSX; off by default) |
 | `--export-llm-prompt` | Write the active prompt to a `.md` file before running (defaults to `maps dir/prompt.md`) |
 | `--output <path>` | Destination `.md` file for `--export-llm-prompt` |
 
@@ -311,6 +311,8 @@ Context from direct imports:
 ```
 
 Pending files are automatically sorted by their dependency graph (topological order) before enrichment — leaf files are processed first. This means `--with-context` produces non-empty context blocks in a **single pass**, even on a fresh index.
+
+Supported languages: Python, TypeScript, JavaScript, TSX. For TS/JS/TSX, the extractor returns extension candidates (`.ts`, `.tsx`, `.js`, `.jsx`, `index.ts`, `index.tsx`) and the index disambiguates automatically. `export … from` re-exports and tsconfig path aliases are not resolved.
 
 Constraints: depth 1 only (no transitive traversal); context is capped at 2000 characters — imports beyond the budget are dropped silently; unknown languages and imports not yet indexed produce no context (silent degradation).
 

--- a/src/sourcemap_indexer/infra/import_extractor.py
+++ b/src/sourcemap_indexer/infra/import_extractor.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import posixpath
+import re
 import sys
 from collections.abc import Callable
+from pathlib import PurePosixPath
 from typing import Protocol
 
 from sourcemap_indexer.domain.value_objects import Language
@@ -72,6 +75,44 @@ class PythonImportExtractor:
         return self._gather(tree)
 
 
+_TS_IMPORT_RE = re.compile(
+    r"""(?:import\s+(?:type\s+)?(?:[\w*{][^'"]*\s+from\s+)?|require\s*\(\s*)['"]([^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+_TS_CANDIDATE_EXTS = (".ts", ".tsx", ".js", ".jsx", "/index.ts", "/index.tsx")
+
+
+def _ts_candidates(base: str) -> list[str]:
+    return [base + ext for ext in _TS_CANDIDATE_EXTS]
+
+
+def _resolve_ts_specifier(specifier: str, file_path: str) -> list[str]:
+    if not (specifier.startswith("./") or specifier.startswith("../") or specifier.startswith("/")):
+        return []
+    raw = str(PurePosixPath(file_path).parent / specifier)
+    base = posixpath.normpath(raw)
+    return _ts_candidates(base)
+
+
+class TypeScriptImportExtractor:
+    def extract(self, content: str, file_path: str) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for match in _TS_IMPORT_RE.finditer(content):
+            specifier = match.group(1)
+            for candidate in _resolve_ts_specifier(specifier, file_path):
+                if candidate not in seen:
+                    seen.add(candidate)
+                    result.append(candidate)
+        return result
+
+
+_ts_extractor = TypeScriptImportExtractor().extract
+
 _EXTRACTORS: dict[Language, Callable[[str, str], list[str]]] = {
     Language.PY: PythonImportExtractor().extract,
+    Language.TS: _ts_extractor,
+    Language.JS: _ts_extractor,
+    Language.TSX: _ts_extractor,
 }

--- a/tests/infra/test_import_extractor.py
+++ b/tests/infra/test_import_extractor.py
@@ -85,5 +85,3 @@ def test_extractors_registry_python_callable_works() -> None:
 
 def test_extractors_registry_unknown_language_absent() -> None:
     assert Language.OTHER not in _EXTRACTORS
-    assert Language.JS not in _EXTRACTORS
-    assert Language.TS not in _EXTRACTORS

--- a/tests/infra/test_ts_import_extractor.py
+++ b/tests/infra/test_ts_import_extractor.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from sourcemap_indexer.domain.value_objects import Language
+from sourcemap_indexer.infra.import_extractor import _EXTRACTORS, TypeScriptImportExtractor
+
+_EXTS = (".ts", ".tsx", ".js", ".jsx")
+_INDEX = ("/index.ts", "/index.tsx")
+
+
+def _candidates(base: str) -> list[str]:
+    return [base + ext for ext in _EXTS] + [base + idx for idx in _INDEX]
+
+
+def test_default_import_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import X from './utils'", "src/app.ts")
+    assert set(result) == set(_candidates("src/utils"))
+
+
+def test_named_import_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import { a, b } from './helpers'", "src/app.ts")
+    assert set(result) == set(_candidates("src/helpers"))
+
+
+def test_namespace_import_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import * as X from './api'", "src/app.ts")
+    assert set(result) == set(_candidates("src/api"))
+
+
+def test_type_import_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import type { Foo } from './types'", "src/app.ts")
+    assert set(result) == set(_candidates("src/types"))
+
+
+def test_require_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("const x = require('./config')", "src/app.ts")
+    assert set(result) == set(_candidates("src/config"))
+
+
+def test_parent_dir_resolution() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import X from '../utils'", "src/components/Button.tsx")
+    assert set(result) == set(_candidates("src/utils"))
+
+
+def test_absolute_specifier_returns_candidates() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import X from '/shared/utils'", "src/app.ts")
+    assert set(result) == set(_candidates("/shared/utils"))
+
+
+def test_export_from_not_matched() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("export { helper } from './utils'", "src/app.ts")
+    assert result == []
+
+
+def test_nested_parent_resolution() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import X from '../../shared'", "src/a/b/c.ts")
+    assert set(result) == set(_candidates("src/shared"))
+
+
+def test_bare_specifier_filtered() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import React from 'react'", "src/app.tsx")
+    assert result == []
+
+
+def test_scoped_package_filtered() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import { something } from '@scope/package'", "src/app.ts")
+    assert result == []
+
+
+def test_multiple_bare_specifiers_all_filtered() -> None:
+    extractor = TypeScriptImportExtractor()
+    content = "import React from 'react'\nimport _ from 'lodash'\nimport axios from 'axios'"
+    result = extractor.extract(content, "src/app.ts")
+    assert result == []
+
+
+def test_mixed_bare_and_relative_returns_only_relative() -> None:
+    extractor = TypeScriptImportExtractor()
+    content = "import React from 'react'\nimport { helper } from './utils'"
+    result = extractor.extract(content, "src/app.ts")
+    assert all("utils" in r for r in result)
+    assert not any("react" in r for r in result)
+
+
+def test_multiple_relative_imports_deduplicates() -> None:
+    extractor = TypeScriptImportExtractor()
+    content = "import { a } from './utils'\nimport { b } from './utils'"
+    result = extractor.extract(content, "src/app.ts")
+    assert len([r for r in result if "utils" in r]) == len(_candidates("src/utils"))
+
+
+def test_empty_content_returns_empty() -> None:
+    extractor = TypeScriptImportExtractor()
+    assert extractor.extract("", "src/app.ts") == []
+
+
+def test_no_imports_returns_empty() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("const x = 1\nconst y = 2", "src/app.ts")
+    assert result == []
+
+
+def test_six_candidates_per_specifier() -> None:
+    extractor = TypeScriptImportExtractor()
+    result = extractor.extract("import X from './foo'", "src/app.ts")
+    assert len(result) == 6
+
+
+def test_extractors_registry_has_ts() -> None:
+    assert Language.TS in _EXTRACTORS
+
+
+def test_extractors_registry_has_js() -> None:
+    assert Language.JS in _EXTRACTORS
+
+
+def test_extractors_registry_has_tsx() -> None:
+    assert Language.TSX in _EXTRACTORS
+
+
+def test_extractors_ts_callable_works() -> None:
+    extract_fn = _EXTRACTORS[Language.TS]
+    result = extract_fn("import X from './utils'", "src/app.ts")
+    assert any("utils" in r for r in result)
+
+
+def test_extractors_js_callable_works() -> None:
+    extract_fn = _EXTRACTORS[Language.JS]
+    result = extract_fn("const x = require('./lib')", "src/app.js")
+    assert any("lib" in r for r in result)
+
+
+def test_extractors_tsx_callable_works() -> None:
+    extract_fn = _EXTRACTORS[Language.TSX]
+    result = extract_fn("import { Component } from './base'", "src/components/App.tsx")
+    assert any("base" in r for r in result)


### PR DESCRIPTION
## Summary

- Adds `TypeScriptImportExtractor` with regex-based parsing of all TS/JS import forms
- Returns 6 extension candidates per relative specifier (`.ts/.tsx/.js/.jsx/index.ts/index.tsx`)
- `pending_paths` filter in `_item_deps` disambiguates automatically — no filesystem I/O in extractor
- Registered for `Language.TS`, `Language.JS`, `Language.TSX` in `_EXTRACTORS`
- `--with-context` now works for Python, TypeScript, JavaScript, and TSX

## Changes

- `infra/import_extractor.py` — `TypeScriptImportExtractor`, `_resolve_ts_specifier`, `_ts_candidates`; registered for TS/JS/TSX
- `tests/infra/test_ts_import_extractor.py` — 23 unit tests covering all import forms, extension resolution, filtering, registry
- `tests/infra/test_import_extractor.py` — updated existing test to remove now-false `JS/TS not in _EXTRACTORS` assertions
- `README.md` — updated `--with-context` to list all supported languages

## Test plan

- [ ] `uv run pytest` — 470 passing, coverage ≥ 95%
- [ ] `sourcemap enrich --with-context` on a TS project — context blocks populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)