### PR TITLE
fix(migrator): wrap migration apply in BEGIN IMMEDIATE transaction

### DIFF
--- a/.docs/issues/approved/14.md
+++ b/.docs/issues/approved/14.md
@@ -1,0 +1,33 @@
+## What
+
+**File:** `src/sourcemap_indexer/infra/migrator.py:16-32`
+
+The migration apply logic reads `_migrations`, checks which are applied, then runs `executescript` + insert — all without an atomic transaction boundary. Two concurrent processes calling `init_db()` (e.g. parallel `sourcemap init` or simultaneous `walk` + `enrich`) can both pass the check and both apply the same migration, causing `SQLITE_BUSY` or duplicate-apply corruption.
+
+## Why
+
+SQLite's default `DEFERRED` isolation does not take a write lock until the first write — the read above doesn't block another process from racing. `BEGIN IMMEDIATE` acquires a reserved lock immediately, making the check-and-apply block atomic.
+
+## Acceptance criteria
+
+- [ ] RED test: spawn 2 threads calling `init_db()` on same DB — assert only one apply path runs
+- [ ] GREEN: migration apply wrapped in `BEGIN IMMEDIATE` with rollback on failure
+- [ ] No regression in existing migrator tests
+- [ ] Coverage ≥ 95% maintained
+
+## Step 1 — Fix concurrent migration race condition in `_apply_pending`
+
+- [x] `[RED]` `[AGENT:tdd-test-writer-agent]` Write failing concurrent test in `tests/infra/test_migrator.py` — spawn 2 threads calling `init_db()` on the same `tmp_path` DB; assert `SELECT COUNT(*) FROM _migrations` equals 1 after both threads complete (no duplicate-apply)
+- [x] `[GREEN]` In `src/sourcemap_indexer/infra/migrator.py`, replace the implicit transaction in `_apply_pending` with `connection.execute("BEGIN IMMEDIATE")` … `connection.commit()` / `connection.rollback()` on exception — eliminates the DEFERRED isolation race window
+- [x] `[INFRA]` Add `connection.execute("PRAGMA journal_mode = WAL")` to `init_db` before `_apply_pending` — reduces `SQLITE_BUSY` frequency under concurrent readers
+- [x] `[AUDIT]` `[AGENT:self-review-agent]` Run step validation — `validate-issue.py --step 1`
+
+## Post-development phases
+
+After all steps are complete, run in order:
+
+1. `/review` — Quality review: static analysis, semantic cross-step review, runtime integration
+2. Fix issues from review report, then re-run `/review` if needed (max 3 cycles)
+3. `/update-docs` — Drift detection: verify incremental doc updates from each step are consistent, update hash
+4. `/review --final` — Final quality gate (delta only: files changed since last review)
+5. `/open-pr` — Create pull request

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 htmlcov/
 .sourcemap/
 .env
+.docs/reviews

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![uv](https://img.shields.io/badge/installed%20via-uv-5c4ee5?logo=astral&logoColor=white)](https://docs.astral.sh/uv/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-470%20passing-brightgreen)](https://github.com/lipex360x/sourcemap-indexer)
+[![Tests](https://img.shields.io/badge/tests-471%20passing-brightgreen)](https://github.com/lipex360x/sourcemap-indexer)
 [![Coverage](https://img.shields.io/badge/coverage-95%25%2B-brightgreen)](https://github.com/lipex360x/sourcemap-indexer)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-strict-blue)](https://mypy.readthedocs.io/)
@@ -661,7 +661,7 @@ Every commit passes a pre-commit pipeline that enforces the following gates:
 ### Testing strategy
 
 - **TDD mandatory** — every behaviour is covered by a test written before the implementation (Red → Green)
-- **No mocks on persistence** — tests hit a real in-memory SQLite database (`":memory:"`)
+- **No mocks on persistence** — tests hit a real in-memory SQLite database (`":memory:"`); concurrency tests use a file-based DB via `tmp_path` (`:memory:` cannot be shared between threads)
 - **No mocks on the filesystem** — tests use `tmp_path` fixtures with real files
 - **Integration tests** run the full CLI via `typer.testing.CliRunner` end-to-end
 - **Coverage minimum: 95%** — enforced both by pytest and by the pre-push hook
@@ -675,5 +675,6 @@ Every commit passes a pre-commit pipeline that enforces the following gates:
 | No comments in source | Names carry meaning. Comments that explain *what* code does rot as code evolves; the only permitted comments are for non-obvious *why* — hidden constraints, workarounds, subtle invariants. |
 | Single output directory (`.sourcemap/`) | Config (`layers.yaml`, `ignore`) and data (`index.db`, `index.yaml`, `logs/`) live under one root. No two directories for the same concern. |
 | `_DEFAULT_LAYERS \| user_layers` | The full valid-layer set is the union of built-in defaults and user-defined additions, computed at startup and passed through to `run_enrich` and `LlmClient`. |
+| `BEGIN IMMEDIATE` + WAL in `init_db` | Migration apply is wrapped in a `BEGIN IMMEDIATE` transaction so two concurrent processes (e.g. parallel `walk` + `enrich`) cannot both pass the "already applied?" check and duplicate a migration. WAL journal mode reduces `SQLITE_BUSY` errors under concurrent readers. |
 
 <div align="right"><a href="#top">↑ back to top</a></div>

--- a/src/sourcemap_indexer/infra/migrator.py
+++ b/src/sourcemap_indexer/infra/migrator.py
@@ -13,29 +13,40 @@ def _load_migration(name: str) -> str:
     return (package / name).read_text(encoding="utf-8")
 
 
+def _run_migration(connection: sqlite3.Connection, name: str) -> None:
+    for statement in _load_migration(name).split(";"):
+        stripped = statement.strip()
+        if stripped:
+            connection.execute(stripped)
+    connection.execute(
+        "INSERT INTO _migrations (name, applied_at) VALUES (?, ?)",
+        (name, int(time.time())),
+    )
+
+
 def _apply_pending(connection: sqlite3.Connection) -> None:
     connection.execute(
         "CREATE TABLE IF NOT EXISTS _migrations "
         "(name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)"
     )
-    applied = {row[0] for row in connection.execute("SELECT name FROM _migrations").fetchall()}
-    migrations = ["001_init.sql"]
-    for name in migrations:
-        if name in applied:
-            continue
-        sql = _load_migration(name)
-        connection.executescript(sql)
-        connection.execute(
-            "INSERT INTO _migrations (name, applied_at) VALUES (?, ?)",
-            (name, int(time.time())),
-        )
     connection.commit()
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        applied = {row[0] for row in connection.execute("SELECT name FROM _migrations").fetchall()}
+        for name in ["001_init.sql"]:
+            if name not in applied:
+                _run_migration(connection, name)
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
 
 
 def init_db(db_path: Path) -> Either[str, sqlite3.Connection]:
     try:
         connection = sqlite3.connect(str(db_path))
         connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA journal_mode = WAL")
         _apply_pending(connection)
         return right(connection)
     except sqlite3.OperationalError as error:

--- a/tests/infra/test_migrator.py
+++ b/tests/infra/test_migrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 from sourcemap_indexer.infra.migrator import init_db
@@ -62,3 +63,32 @@ def test_init_db_returns_left_for_invalid_path() -> None:
     result = init_db(Path("/nonexistent_dir/that/does/not/exist/test.db"))
     assert isinstance(result, Left)
     assert result.error.startswith("db-error")
+
+
+def test_init_db_is_safe_under_concurrent_calls(tmp_path: Path) -> None:
+    db_path = tmp_path / "concurrent.db"
+    failures: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            outcome = init_db(db_path)
+            if isinstance(outcome, Right):
+                outcome.value.close()
+        except BaseException as thrown:
+            failures.append(thrown)
+
+    first_thread = threading.Thread(target=run)
+    second_thread = threading.Thread(target=run)
+    first_thread.start()
+    second_thread.start()
+    first_thread.join()
+    second_thread.join()
+
+    assert not failures, f"thread raised: {failures[0]}"
+
+    verification = init_db(db_path)
+    assert isinstance(verification, Right)
+    counter = verification.value.execute("SELECT COUNT(*) FROM _migrations")
+    count = counter.fetchone()[0]
+    verification.value.close()
+    assert count == 1

--- a/tests/infra/test_migrator.py
+++ b/tests/infra/test_migrator.py
@@ -74,7 +74,7 @@ def test_init_db_is_safe_under_concurrent_calls(tmp_path: Path) -> None:
             outcome = init_db(db_path)
             if isinstance(outcome, Right):
                 outcome.value.close()
-        except BaseException as thrown:
+        except Exception as thrown:
             failures.append(thrown)
 
     first_thread = threading.Thread(target=run)


### PR DESCRIPTION
## Summary

- Wraps `_apply_pending` read-check-write sequence in `BEGIN IMMEDIATE` transaction, eliminating the race window where two concurrent processes (e.g. `walk` + `enrich`) could both pass the "already applied?" check and duplicate a migration
- Adds `PRAGMA journal_mode = WAL` before `_apply_pending` to reduce `SQLITE_BUSY` under concurrent readers
- Adds concurrent-safety test: two threads call `init_db()` on the same file-based DB simultaneously; asserts `_migrations` count == 1 after both complete
- Updates README: test badge (470 → 471), testing strategy note for concurrency tests, design decision entry for `BEGIN IMMEDIATE` + WAL

## Test plan

- [ ] 471 tests pass, coverage ≥ 95% (95.67%)
- [ ] Concurrent test runs 10/10 without flakiness
- [ ] `journal_mode=wal` confirmed on file-based DB after `init_db`
- [ ] Editable install (`sourcemap --help`) healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)