### PR TITLE
feat(walk): atomic tmp+replace write for index.yaml

### DIFF
--- a/.docs/issues/approved/16.md
+++ b/.docs/issues/approved/16.md
@@ -1,0 +1,36 @@
+## What
+
+`run_walk` in `application/walk.py:56` calls `output_path.write_text(...)` directly. This is non-atomic — an interrupted run or concurrent read from `sync` can expose a truncated or corrupt `index.yaml`.
+
+## Why
+
+- An interrupted `walk` leaves a partial file at `output_path`
+- `sync` opening `index.yaml` mid-write receives partial YAML → parse error
+- `os.replace()` is atomic on POSIX and Windows: the target either has the old content or the new content, never something in between
+
+## Acceptance criteria
+
+- [ ] RED test: simulate mid-write by asserting `output_path` never exists in truncated state (use a custom `write_text` mock that raises after half the bytes)
+- [ ] GREEN: tmp+replace implementation
+- [ ] Cleanup of `.tmp` file on failure
+- [ ] Coverage ≥ 95%
+
+## Steps
+
+### Step 1 — RED: tests for atomic write contract
+
+- [x] `[RED]` `[AGENT:tdd-test-writer-agent]` Write test: when `Path.write_text` raises mid-write on the `.tmp` file, `output_path` stays absent (never truncated)
+- [x] `[RED]` `[AGENT:tdd-test-writer-agent]` Write test: `.tmp` sibling file is removed after a write failure (no leftover temp)
+- [x] `[RED]` `[AGENT:tdd-test-writer-agent]` Write test: `.tmp` sibling file is absent after a successful write
+- [x] `[AUDIT]` `[AGENT:self-review-agent]` Run step validation — tag order, checkbox format, no consecutive RED without GREEN
+
+### Step 2 — GREEN: implement tmp+replace
+
+- [x] `[GREEN]` Replace the `write_text` call with: write YAML to `output_path.with_suffix(".yaml.tmp")`, then `os.replace(tmp, output_path)` — add `import os` at top
+- [x] `[GREEN]` On `OSError`, call `tmp_path.unlink(missing_ok=True)` before returning `left(f"write-error: {error}")`
+- [x] `[INFRA]` Remove the `# nosemgrep: python-non-atomic-write` comment (semgrep suppression no longer needed)
+- [x] `[AUDIT]` `[AGENT:self-review-agent]` Run step validation — verify coverage ≥ 95%, all tests green
+
+## Post-development phases
+
+`/review` → `/update-docs` → `/open-pr`

--- a/src/sourcemap_indexer/application/walk.py
+++ b/src/sourcemap_indexer/application/walk.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import os
 import time
 from pathlib import Path
 
@@ -50,9 +52,13 @@ def run_walk(
             for file in walked
         ],
     }
+    temp_path = output_path.with_suffix(".yaml.tmp")
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(yaml.dump(index, allow_unicode=True), encoding="utf-8")
+        temp_path.write_text(yaml.dump(index, allow_unicode=True), encoding="utf-8")
+        os.replace(temp_path, output_path)
     except OSError as error:
+        with contextlib.suppress(OSError):
+            temp_path.unlink(missing_ok=True)
         return left(f"write-error: {error}")
     return right(len(walked))

--- a/tests/application/test_walk.py
+++ b/tests/application/test_walk.py
@@ -148,3 +148,53 @@ def test_run_walk_output_outside_root_does_not_add_ignore_pattern(tmp_path: Path
     assert isinstance(result, Right)
     (outside_dir / "index.yaml").unlink(missing_ok=True)
     outside_dir.rmdir()
+
+
+def test_run_walk_output_path_absent_when_tmp_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "main.py").write_text("x = 1\n")
+    output = tmp_path / "index.yaml"
+    temp_file = output.with_suffix(".yaml.tmp")
+
+    original_write = Path.write_text
+
+    def fail_on_temp(self: Path, text: str, **kwargs: object) -> None:
+        if self == temp_file:
+            raise OSError("simulated mid-write failure")
+        return original_write(self, text, **kwargs)  # type: ignore[return-value]
+
+    monkeypatch.setattr(Path, "write_text", fail_on_temp)
+    result = run_walk(tmp_path, output)
+
+    assert isinstance(result, Left)
+    assert not output.exists()
+
+
+def test_run_walk_no_leftover_temp_on_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "main.py").write_text("x = 1\n")
+    output = tmp_path / "index.yaml"
+    temp_file = output.with_suffix(".yaml.tmp")
+    temp_file.write_text("stale")
+
+    def always_fail(self: Path, text: str, **kwargs: object) -> None:
+        raise OSError("simulated disk-full failure")
+
+    monkeypatch.setattr(Path, "write_text", always_fail)
+    run_walk(tmp_path, output)
+
+    assert not temp_file.exists()
+
+
+def test_run_walk_no_leftover_temp_on_success(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("x = 1\n")
+    output = tmp_path / "index.yaml"
+    temp_file = output.with_suffix(".yaml.tmp")
+    temp_file.write_text("stale")
+
+    result = run_walk(tmp_path, output)
+
+    assert isinstance(result, Right)
+    assert not temp_file.exists()


### PR DESCRIPTION
## Summary

- Substitui `output_path.write_text(...)` por escrita em `.yaml.tmp` + `os.replace()` para garantir atomicidade no POSIX e Windows
- Adiciona cleanup de `.yaml.tmp` com `contextlib.suppress(OSError)` em caso de falha
- 3 novos testes cobrem: output ausente após falha no tmp, sem leftover temp na falha, sem leftover temp no sucesso

Closes #16

## Test plan

- [x] `test_run_walk_output_path_absent_when_tmp_write_fails` — output nunca criado se write no tmp falha
- [x] `test_run_walk_no_leftover_temp_on_write_failure` — `.yaml.tmp` removido após falha
- [x] `test_run_walk_no_leftover_temp_on_success` — `.yaml.tmp` removido após sucesso
- [x] 585 testes passando, coverage 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)